### PR TITLE
Add Raspberry Pi control guide and PCA9685 controller script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,118 @@
-# zibidi
-ZIBIDI is open source quadrupedal robot project
+# ZIBIDI Quadruped Robot
 
-Thingiverse:
-https://www.thingiverse.com/thing:4600316
+ZIBIDI is an open-source quadruped robot that can be fabricated with readily available 3D-printable parts and off-the-shelf electronics. This repository aggregates the printable models and documentation needed to assemble a robot powered by a Raspberry Pi 4B and a PCA9685 PWM servo controller.
+
+Thingiverse page for the printable parts: https://www.thingiverse.com/thing:4600316
+
+## Project Overview
+
+The robot uses 12 servo motors (3 per leg) to achieve 3 degrees of freedom in each limb. A Raspberry Pi 4B serves as the primary computer, handling high-level gait generation, while a PCA9685 16-channel PWM driver generates the servo control signals. The Pi communicates with the PCA9685 over the I2C bus, freeing CPU resources for perception and control algorithms.
+
+Key subsystems:
+
+* **Mechanical** – 3D printed chassis, legs, and covers (see the `3d-printable-files` directory for STL files).
+* **Electronics** – Raspberry Pi 4B, PCA9685 servo driver, power distribution board, 12 × hobby servos (MG996R or similar), and a 2S/3S LiPo battery with a 6 V BEC.
+* **Software** – Python-based control stack using Adafruit's CircuitPython libraries for the PCA9685. The included script demonstrates how to map joint angles to servo pulse widths and run basic standing and walking motions.
+
+## Bill of Materials
+
+The [BOM-ZIBIDI.xlsx](./BOM-ZIBIDI.xlsx) file lists reference components for the mechanical build. The additional electronics below integrate the Raspberry Pi and PCA9685:
+
+| Quantity | Component | Notes |
+| --- | --- | --- |
+| 1 | Raspberry Pi 4 Model B (2 GB+ RAM) | Runs Linux-based control software. |
+| 1 | MicroSD card (32 GB+) | With Raspberry Pi OS. |
+| 1 | PCA9685 16-Channel 12-bit PWM Driver | I2C address selectable via A0–A5 jumpers; default `0x40`. |
+| 12 | Metal-gear servos (MG996R or equivalent) | Ensure 180° range and 6 V operation. |
+| 1 | 5–6 V / 5 A BEC or DC-DC regulator | Powers servos from LiPo battery. |
+| 1 | 2S or 3S LiPo battery (2200 mAh+) | Connect through BEC to PCA9685 V+ rail. |
+| 1 | Logic-level shifter (optional) | Pi GPIO is 3.3 V; PCA9685 accepts 3.3 V I2C directly. |
+| — | Dupont jumper wires, screw terminals, power switch | For wiring and power management. |
+
+## Mechanical Assembly
+
+1. Print the STL files from `3d-printable-files/V4.0` for the latest leg design (or `V3.0` for the earlier variant).
+2. Clean and post-process the parts as needed (sanding, removing supports).
+3. Assemble each leg: mount three servos per leg to provide hip roll, hip pitch, and knee pitch joints.
+4. Route servo cables through the chassis, labeling each channel (e.g., `FR_HIP_ROLL`, `FR_HIP_PITCH`, etc.).
+5. Mount the Raspberry Pi and PCA9685 board on the equipment plate; ensure airflow and cable clearance.
+6. Install the top cover once the electronics and wiring are tested.
+
+> **Tip:** Keep servo horns centered before installation. Power the servos from a calibration fixture, send a 1500 µs pulse, and mechanically align each leg to its neutral pose.
+
+## Electronics & Wiring
+
+```
+Raspberry Pi 4B        PCA9685 Board
+------------------     -------------------------------
+3.3V (pin 1)  ------>  VCC (logic power)
+GND (pin 6)   ------>  GND
+SDA (pin 3)   ------>  SDA
+SCL (pin 5)   ------>  SCL
+
+External 6 V BEC  --->  V+ rail on PCA9685 (servo power)
+External BEC GND  --->  GND (shared with Pi)
+Servos            --->  PCA9685 output channels 0–11
+```
+
+* Keep the Raspberry Pi powered from its USB-C supply or a regulated 5 V rail. Do **not** power the Pi directly from the servo supply.
+* Use ferrite beads or twisted pairs on servo power leads to reduce noise.
+* Add a large electrolytic capacitor (≥1000 µF, 10 V) across the PCA9685 V+ and GND pins to smooth current spikes.
+
+## Software Setup
+
+1. Flash Raspberry Pi OS (64-bit) onto the microSD card and boot the Pi.
+2. Enable the I2C interface using `sudo raspi-config` → *Interface Options* → *I2C*.
+3. Update packages and install Python tooling:
+
+   ```bash
+   sudo apt update
+   sudo apt install python3-pip python3-venv i2c-tools
+   sudo usermod -aG i2c $USER
+   reboot
+   ```
+
+4. Clone this repository onto the Pi and install the software dependencies:
+
+   ```bash
+   git clone https://github.com/<your-user>/zibidi.git
+   cd zibidi/software
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+5. Verify the PCA9685 is visible on the I2C bus:
+
+   ```bash
+   sudo i2cdetect -y 1
+   ```
+
+   You should see `0x40` (or your configured address) in the scan output.
+
+6. Run the controller demo:
+
+   ```bash
+   python zibidi_controller.py
+   ```
+
+   The script stands the robot up, cycles a weight-shift routine, and then returns to a neutral pose. Modify the `GAITS` dictionary for additional motion experiments.
+
+## Calibrating Servos
+
+1. Start with the robot supported in the air so the feet do not touch the ground.
+2. Use the `--calibrate` flag in `zibidi_controller.py` to command each joint to a neutral 90° position. Adjust the servo horn on the spline until the limb matches the mechanical neutral.
+3. Enter measured offsets (in degrees) into the `SERVO_OFFSETS` dictionary.
+4. Repeat for all 12 joints.
+
+## Advanced Development Ideas
+
+* Integrate an IMU (e.g., BNO085) for balance control; connect over I2C and fuse sensor data with complementary or Kalman filtering.
+* Port gait generation to ROS 2 and publish joint trajectories using `trajectory_msgs/JointTrajectory` messages.
+* Add a depth camera or stereo vision module to the Raspberry Pi and implement terrain-aware foot placement.
+* Experiment with reinforcement learning policies trained in simulation (Isaac Gym, PyBullet) and deployed on the Pi.
+
+## Contributing
+
+Pull requests are welcome! Please include wiring diagrams, improved gaits, or additional software modules that extend the robot's capabilities.
+

--- a/software/requirements.txt
+++ b/software/requirements.txt
@@ -1,0 +1,2 @@
+adafruit-circuitpython-servokit>=1.3.8
+numpy>=1.24

--- a/software/zibidi_controller.py
+++ b/software/zibidi_controller.py
@@ -1,0 +1,246 @@
+"""Basic control routines for the ZIBIDI quadruped robot.
+
+This module provides a command-line interface that can drive 12 servos through
+an Adafruit PCA9685 board connected to a Raspberry Pi 4B. It supports
+calibrating neutral offsets and executing a small selection of open-loop gaits.
+
+Example
+-------
+Run the default standing pose and gentle weight-shift routine::
+
+    $ python zibidi_controller.py
+
+Calibrate each joint::
+
+    $ python zibidi_controller.py --calibrate
+
+The calibration command walks through each joint sequentially, waiting for user
+confirmation before moving on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import time
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+
+try:
+    from adafruit_servokit import ServoKit
+except ImportError as exc:  # pragma: no cover - hardware dependency
+    raise SystemExit(
+        "adafruit-circuitpython-servokit is required. Install dependencies with "
+        "'pip install -r requirements.txt'."
+    ) from exc
+
+
+# The PCA9685 board used by Adafruit's ServoKit has 16 channels. We use 12 for
+# the quadruped joints and keep the remaining channels in reserve for grippers
+# or sensors.
+KIT = ServoKit(channels=16)
+
+
+@dataclasses.dataclass(frozen=True)
+class Joint:
+    """Represents a single servo joint on the robot."""
+
+    channel: int
+    min_angle: float = -60.0
+    max_angle: float = 60.0
+
+    def clamp(self, angle: float) -> float:
+        """Clamp ``angle`` to the joint's mechanical limits."""
+
+        return float(np.clip(angle, self.min_angle, self.max_angle))
+
+
+# Joint ordering follows: [front-right, front-left, rear-right, rear-left] ×
+# [hip roll, hip pitch, knee pitch]
+JOINTS: Dict[str, Joint] = {
+    # Front right (FR)
+    "FR_HIP_ROLL": Joint(0, -35, 35),
+    "FR_HIP_PITCH": Joint(1, -50, 50),
+    "FR_KNEE": Joint(2, -60, 60),
+    # Front left (FL)
+    "FL_HIP_ROLL": Joint(3, -35, 35),
+    "FL_HIP_PITCH": Joint(4, -50, 50),
+    "FL_KNEE": Joint(5, -60, 60),
+    # Rear right (RR)
+    "RR_HIP_ROLL": Joint(6, -35, 35),
+    "RR_HIP_PITCH": Joint(7, -50, 50),
+    "RR_KNEE": Joint(8, -60, 60),
+    # Rear left (RL)
+    "RL_HIP_ROLL": Joint(9, -35, 35),
+    "RL_HIP_PITCH": Joint(10, -50, 50),
+    "RL_KNEE": Joint(11, -60, 60),
+}
+
+
+# Offsets in degrees that align the mechanical neutral pose (legs vertical) with
+# the servo controller's 90° neutral position. Modify after running calibration.
+SERVO_OFFSETS: Dict[str, float] = {
+    name: 0.0 for name in JOINTS
+}
+
+
+# Default stance angles for each joint (in degrees relative to neutral).
+STANCE: Dict[str, float] = {
+    "FR_HIP_ROLL": 0.0,
+    "FR_HIP_PITCH": 10.0,
+    "FR_KNEE": -20.0,
+    "FL_HIP_ROLL": 0.0,
+    "FL_HIP_PITCH": 10.0,
+    "FL_KNEE": -20.0,
+    "RR_HIP_ROLL": 0.0,
+    "RR_HIP_PITCH": 10.0,
+    "RR_KNEE": -20.0,
+    "RL_HIP_ROLL": 0.0,
+    "RL_HIP_PITCH": 10.0,
+    "RL_KNEE": -20.0,
+}
+
+
+# Gait keyframes expressed as (duration_seconds, {joint_name: delta_angle}). The
+# joint deltas are relative to the neutral stance defined above.
+GAITS: Dict[str, List[Tuple[float, Dict[str, float]]]] = {
+    "idle_shift": [
+        (1.2, {
+            "FR_HIP_ROLL": -6.0,
+            "RR_HIP_ROLL": -6.0,
+            "FL_HIP_ROLL": 6.0,
+            "RL_HIP_ROLL": 6.0,
+        }),
+        (1.2, {
+            "FR_HIP_ROLL": 6.0,
+            "RR_HIP_ROLL": 6.0,
+            "FL_HIP_ROLL": -6.0,
+            "RL_HIP_ROLL": -6.0,
+        }),
+    ],
+    "crawl_forward": [
+        (0.8, {
+            "FR_HIP_PITCH": -8.0,
+            "FR_KNEE": 12.0,
+        }),
+        (0.4, {
+            "FR_HIP_PITCH": 4.0,
+            "FR_KNEE": -12.0,
+            "RR_HIP_PITCH": 4.0,
+            "RR_KNEE": -8.0,
+        }),
+        (0.8, {
+            "FL_HIP_PITCH": -8.0,
+            "FL_KNEE": 12.0,
+        }),
+        (0.4, {
+            "FL_HIP_PITCH": 4.0,
+            "FL_KNEE": -12.0,
+            "RL_HIP_PITCH": 4.0,
+            "RL_KNEE": -8.0,
+        }),
+    ],
+}
+
+
+def set_joint_angle(joint_name: str, angle: float) -> None:
+    """Set ``joint_name`` to ``angle`` degrees relative to neutral."""
+
+    joint = JOINTS[joint_name]
+    target = joint.clamp(angle + SERVO_OFFSETS[joint_name] + 90.0)
+    KIT.servo[joint.channel].angle = target
+
+
+def go_to_pose(pose: Dict[str, float], duration: float, steps: int = 20) -> None:
+    """Interpolate to ``pose`` in ``duration`` seconds."""
+
+    current = {name: KIT.servo[joint.channel].angle or 90.0 for name, joint in JOINTS.items()}
+    current_rel = {name: angle - (SERVO_OFFSETS[name] + 90.0) for name, angle in current.items()}
+
+    for alpha in np.linspace(0.0, 1.0, steps):
+        for joint_name, target_rel in pose.items():
+            interpolated = (1 - alpha) * current_rel[joint_name] + alpha * target_rel
+            set_joint_angle(joint_name, interpolated)
+        time.sleep(duration / steps)
+
+
+def enter_stance(duration: float = 1.5) -> None:
+    """Move the robot into its neutral stance."""
+
+    go_to_pose(STANCE, duration)
+
+
+def run_gait(gait_name: str, cycles: int) -> None:
+    """Execute a gait by name for the requested number of cycles."""
+
+    if gait_name not in GAITS:
+        raise ValueError(f"Unknown gait '{gait_name}'. Valid options: {', '.join(GAITS)}")
+
+    keyframes = GAITS[gait_name]
+    for _ in range(cycles):
+        for duration, deltas in keyframes:
+            pose = {name: STANCE.get(name, 0.0) + delta for name, delta in deltas.items()}
+            go_to_pose(pose, duration)
+
+
+def calibrate(order: Iterable[str] | None = None) -> None:
+    """Interactively calibrate each joint."""
+
+    if order is None:
+        order = JOINTS.keys()
+
+    print("Starting calibration. Ensure the robot is lifted off the ground.")
+    for joint_name in order:
+        input(f"Press Enter to center {joint_name}...")
+        set_joint_angle(joint_name, 0.0)
+        print(
+            "Adjust the servo horn so the limb is neutral, then record the offset in "
+            "SERVO_OFFSETS.")
+    print("Calibration routine complete.")
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--gait",
+        default="idle_shift",
+        choices=list(GAITS.keys()),
+        help="Open-loop gait to execute after entering stance",
+    )
+    parser.add_argument(
+        "--cycles",
+        type=int,
+        default=2,
+        help="Number of cycles to run the selected gait",
+    )
+    parser.add_argument(
+        "--calibrate",
+        action="store_true",
+        help="Run interactive servo calibration",
+    )
+    parser.add_argument(
+        "--no-stance",
+        action="store_true",
+        help="Skip moving into the default stance before running the gait",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.calibrate:
+        calibrate()
+        return 0
+
+    if not args.no_stance:
+        enter_stance()
+
+    run_gait(args.gait, args.cycles)
+    enter_stance(duration=1.0)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- expand the README with assembly, wiring, and software setup instructions for a Raspberry Pi 4B and PCA9685-powered build
- add a Python control script that drives the robot's 12 servos, supports calibration, and includes sample gaits
- document Python dependencies required to run the new controller

## Testing
- python -m compileall software

------
https://chatgpt.com/codex/tasks/task_e_68f87e31ab7c832f91897a0b4254d324